### PR TITLE
fix: 所有内部链接支持动态 BASE_PATH

### DIFF
--- a/src/components/BackButton.astro
+++ b/src/components/BackButton.astro
@@ -2,6 +2,7 @@
 import IconChevronLeft from "@/assets/icons/IconChevronLeft.svg";
 import LinkButton from "./LinkButton.astro";
 import { SITE } from "@/config";
+import { getUrl } from "@/utils/getUrl";
 ---
 
 {
@@ -9,7 +10,7 @@ import { SITE } from "@/config";
     <div class="app-layout flex items-center justify-start">
       <LinkButton
         id="back-button"
-        href="/"
+        href={getUrl("/")}
         class="focus-outline -ms-2 mt-8 mb-2 hover:text-foreground/75"
       >
         <IconChevronLeft class="inline-block size-6 rtl:rotate-180" />

--- a/src/components/Breadcrumb.astro
+++ b/src/components/Breadcrumb.astro
@@ -36,6 +36,8 @@ if (breadcrumbList[0] === "tags" && !isNaN(Number(breadcrumbList[2]))) {
 function getDisplayName(path: string): string {
   return pathNameMap[path] || path;
 }
+
+import { getUrl } from "@/utils/getUrl";
 ---
 
 <nav class="app-layout mt-8 mb-1" aria-label="breadcrumb">
@@ -43,7 +45,7 @@ function getDisplayName(path: string): string {
     class="font-light [&>li]:inline [&>li:not(:last-child)>a]:hover:opacity-100"
   >
     <li>
-      <a href="/" class="opacity-80">首页</a>
+      <a href={getUrl("/")} class="opacity-80">首页</a>
       <span aria-hidden="true" class="opacity-80">&raquo;</span>
     </li>
     {
@@ -59,7 +61,7 @@ function getDisplayName(path: string): string {
           </li>
         ) : (
           <li>
-            <a href={`/${breadcrumb}.html`} class="opacity-70">
+            <a href={getUrl(`/${breadcrumb}.html`)} class="opacity-70">
               {getDisplayName(breadcrumb)}
             </a>
             <span aria-hidden="true">&raquo;</span>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -8,6 +8,7 @@ import IconMenuDeep from "@/assets/icons/IconMenuDeep.svg";
 import IconLogo from "@/assets/icons/IconLogo.svg";
 import LinkButton from "./LinkButton.astro";
 import { SITE } from "@/config";
+import { getUrl } from "@/utils/getUrl";
 
 const { pathname } = Astro.url;
 
@@ -44,7 +45,7 @@ const isActive = (path: string) => {
     ]}
   >
     <a
-      href="/"
+      href={getUrl("/")}
       class="absolute flex items-center gap-2 py-1 whitespace-nowrap sm:static sm:my-auto"
     >
       <IconLogo class="size-7 sm:size-8" />
@@ -77,20 +78,23 @@ const isActive = (path: string) => {
       >
         <li class="col-span-2">
           <a
-            href="/posts.html"
+            href={getUrl("/posts.html")}
             class:list={{ "active-nav": isActive("/posts") }}
           >
             文章
           </a>
         </li>
         <li class="col-span-2">
-          <a href="/tags.html" class:list={{ "active-nav": isActive("/tags") }}>
+          <a
+            href={getUrl("/tags.html")}
+            class:list={{ "active-nav": isActive("/tags") }}
+          >
             标签
           </a>
         </li>
         <li class="col-span-2">
           <a
-            href="/about.html"
+            href={getUrl("/about.html")}
             class:list={{ "active-nav": isActive("/about") }}
           >
             关于
@@ -100,7 +104,7 @@ const isActive = (path: string) => {
           SITE.showArchives && (
             <li class="col-span-2">
               <LinkButton
-                href="/archives.html"
+                href={getUrl("/archives.html")}
                 class:list={[
                   "focus-outline flex justify-center p-3 sm:p-1",
                   {
@@ -118,7 +122,7 @@ const isActive = (path: string) => {
         }
         <li class="col-span-1 flex items-center justify-center">
           <LinkButton
-            href="/search.html"
+            href={getUrl("/search.html")}
             class:list={[
               "focus-outline flex p-3 sm:p-1",
               { "[&>svg]:stroke-accent": isActive("/search") },

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -3,6 +3,7 @@ import { Font } from "astro:assets";
 import { ClientRouter } from "astro:transitions";
 import { PUBLIC_GOOGLE_SITE_VERIFICATION } from "astro:env/client";
 import { SITE } from "@/config";
+import { getUrl } from "@/utils/getUrl";
 import "@/styles/global.css";
 
 type Props = {
@@ -57,7 +58,7 @@ const structuredData = {
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" type="image/svg+xml" href={getUrl("/favicon.svg")} />
     <link rel="canonical" href={canonicalURL} />
     <meta name="generator" content={Astro.generator} />
 
@@ -72,7 +73,7 @@ const structuredData = {
     <meta name="title" content={title} />
     <meta name="description" content={description} />
     <meta name="author" content={author} />
-    <link rel="sitemap" href="/sitemap-index.xml" />
+    <link rel="sitemap" href={getUrl("/sitemap-index.xml")} />
 
     <!-- Open Graph / Facebook -->
     <meta property="og:title" content={title} />

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -4,6 +4,7 @@ import Header from "@/components/Header.astro";
 import Footer from "@/components/Footer.astro";
 import LinkButton from "@/components/LinkButton.astro";
 import { SITE } from "@/config";
+import { getUrl } from "@/utils/getUrl";
 ---
 
 <Layout title={`404 Not Found | ${SITE.title}`}>
@@ -18,7 +19,7 @@ import { SITE } from "@/config";
       <span aria-hidden="true">¯\_(ツ)_/¯</span>
       <p class="mt-4 text-2xl sm:text-3xl">Page Not Found</p>
       <LinkButton
-        href="/"
+        href={getUrl("/")}
         class="my-6 text-lg underline decoration-dashed underline-offset-8"
       >
         Go back home

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -11,6 +11,7 @@ import IconRss from "@/assets/icons/IconRss.svg";
 import IconArrowRight from "@/assets/icons/IconArrowRight.svg";
 import { SITE } from "@/config";
 import { SOCIALS } from "@/constants";
+import { getUrl } from "@/utils/getUrl";
 
 const posts = await getCollection("blog");
 
@@ -28,7 +29,7 @@ const recentPosts = sortedPosts;
       </h1>
       <a
         target="_blank"
-        href="/rss.xml"
+        href={getUrl("/rss.xml")}
         class="inline-block"
         aria-label="rss feed"
         title="RSS Feed"
@@ -53,13 +54,13 @@ const recentPosts = sortedPosts;
         欢迎阅读
         <LinkButton
           class="underline decoration-dashed underline-offset-4 hover:text-accent"
-          href="/posts.html"
+          href={getUrl("/posts.html")}
         >
           全部文章
         </LinkButton> 或了解
         <LinkButton
           class="underline decoration-dashed underline-offset-4 hover:text-accent"
-          href="/about.html"
+          href={getUrl("/about.html")}
         >
           关于我
         </LinkButton>。
@@ -121,7 +122,7 @@ const recentPosts = sortedPosts;
     }
 
     <div class="my-8 text-center">
-      <LinkButton href="/posts.html">
+      <LinkButton href={getUrl("/posts.html")}>
         全部文章
         <IconArrowRight class="inline-block rtl:-rotate-180" />
       </LinkButton>

--- a/src/utils/getUrl.ts
+++ b/src/utils/getUrl.ts
@@ -1,0 +1,19 @@
+/**
+ * 获取带 base 路径的 URL
+ * @param path - 路径，如 "/" 或 "/posts.html"
+ * @returns 完整路径，如 "/MyBlog/" 或 "/MyBlog/posts.html"
+ */
+export function getUrl(path: string): string {
+  const base = (import.meta.env.BASE_URL || "/").replace(/\/$/, "");
+  // 如果 path 已经是完整 URL 或以 # 开头，直接返回
+  if (path.startsWith("http") || path.startsWith("#")) {
+    return path;
+  }
+  // 确保 path 以 / 开头
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  // 如果 base 是 /，直接返回 path
+  if (base === "") {
+    return normalizedPath;
+  }
+  return `${base}${normalizedPath}`;
+}


### PR DESCRIPTION
## Summary
- 新增 `getUrl()` 工具函数统一处理 `BASE_URL` 前缀
- 修复所有组件中的硬编码链接，确保在 GitHub Pages (`/MyBlog`) 和自部署 (`/`) 环境下都能正常工作

## Changed Files
- `src/utils/getUrl.ts` - 新增工具函数
- `src/components/Header.astro` - 导航链接
- `src/components/BackButton.astro` - 返回按钮
- `src/components/Breadcrumb.astro` - 面包屑导航
- `src/pages/404.astro` - 404 页面返回首页
- `src/layouts/Layout.astro` - favicon、sitemap
- `src/pages/index.astro` - 首页内部链接

## Test plan
- [ ] 验证 GitHub Pages 部署后所有链接正常
- [ ] 点击文章标题能正确跳转
- [ ] 点击返回按钮能回到首页
- [ ] 面包屑导航链接正常
- [ ] favicon 和 sitemap 正常加载

🤖 Generated with [Claude Code](https://claude.com/claude-code)